### PR TITLE
Updating jq-src to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default = ["pkg-config"]
 bundled = ["jq-src"]
 
 [build-dependencies]
-jq-src = { version = "0.3", optional = true }
+jq-src = { version = "0.4", optional = true }
 pkg-config = { version = "0.3.14", optional = true }
 
 [package.metadata.docs.rs]

--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ extern crate pkg_config;
 
 #[cfg(feature = "bundled")]
 fn build_bundled() {
-    jq_src::Build::new().build().print_link_info();
+    jq_src::build().expect("autotools build").print_cargo_metadata();
 }
 
 #[cfg(not(feature = "bundled"))]


### PR DESCRIPTION
The new release of jq-src should hopefully solve the intermittent build issues seen when using the `bundled` feature (see onelson/jq-src#1 for limited details).